### PR TITLE
Adding MAILMAP template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ Samvera projects. Should be included. Minimal customization should be necessary.
 verbatim in every Samvera repository. If this is updated, it needs to be
 distributed to all Samvera organization repositories.
 
+
 [LICENSE](./templates/LICENSE) - Should be included in every Samvera
 repository. The copyright statements may change as appropriate. This template
 was taken from guidelines found on the
 [wiki](https://wiki.duraspace.org/display/samvera/Code+Copyright+Statement).
+
+[MAILMAP](./templates/MAILMAP) - A master template for [git mailmap](https://www.git-scm.com/docs/git-check-mailmap).
+This template is something to push to all samvera repositories. The goal in
+applying a common mailmap is to help understand contributions as people move
+and change roles/functions/laptops.
 
 ## Rake Tasks
 

--- a/templates/MAILMAP
+++ b/templates/MAILMAP
@@ -1,0 +1,143 @@
+Aaron Collier <aaron.collier@stanford.edu> <acollier@acollier-mac01.local>
+Aaron Collier <aaron.collier@stanford.edu> <acollier@calstate.edu>
+Aaron Collier <aaron.collier@stanford.edu> <acollier@sufia-dev.attlocal.net>
+Adam Arling <adam.arling@northwestern.edu> <adamjarling@users.noreply.github.com>
+Adam Wead <amsterdamos@gmail.com> <awead@rockhall.org>
+Adam Wead <amsterdamos@gmail.com> Adam Wead <awead@users.noreply.github.com>
+Alicia Cozine <alicia@curationexperts.com> <cozi@visi.com>
+Alicia Cozine <alicia@curationexperts.com> Alicia Cozine <cozi@visi.com>
+Andrew Curley <andrew.curley@gmail.com> <andrew.curley@treasury.gov>
+Andrew Myers <afredmyers@gmail.com> <andrew_myers@wgbh.org>
+Andrew Myers <afredmyers@gmail.com> afred <afredmyers@gmail.com>
+Andrew Myers <afredmyers@gmail.com> Andrew Myers <andrew_myers@wgbh.org>
+Anna Headley <anna.headley@gmail.com> <anna.headley@gmail.com>
+Anna Headley <anna.headley@gmail.com> <anna3LC@gmail.com>
+Banurekha L <banurekha.l@gmail.com> <blakshmi@nd.edu>
+Banurekha L <banurekha.l@gmail.com> banurekha <banurekha.l@gmail.com>
+Banurekha L <banurekha.l@gmail.com> Banurekha <banurekha.l@gmail.com>
+Bess Sadler <bess@curationexperts.com> Bess Sadler <bess@stanford.edu>
+Blimey74 <jatr@kb.dk> blimey74 <blimey74@users.noreply.github.com>
+Blimey74 <jatr@kb.dk> blimey74 <jatr@kb.dk>
+Brendan Quinn <brendan-quinn@northwestern.edu> <brendan-quinn@northwestern.edu>
+Carolyn Cole <cam156@psu.edu> cam156
+Carolyn Cole <cam156@psu.edu> cam156 <cam156@psu.edu>
+Carolyn Cole <cam156@psu.edu> Carolyn <carolyn@carolyn-VirtualBox.(none)>
+Carrick Rogers <carrickr@users.noreply.github.com> Carrick Rogers <carrickr@iu.edu>
+Carrick Rogers <carrickr@users.noreply.github.com> Carrick Rogers <carrickr@umich.edu>
+Chris Beer <chris@cbeer.info> <cabeer@stanford.edu>
+Chris Beer <chris@cbeer.info> <chris_beer@wgbh.org>
+Chris Beer <chris@cbeer.info> <chris@cbeer.info>
+Chris Colvard <cjcolvar@indiana.edu> Chris Colvard <cjcolvar@Chriss-MacBook-Pro.local>
+Chris Colvard <cjcolvar@indiana.edu> cjcolvar <cjcolvar@indiana.edu>
+Chris Diaz <chris-diaz@northwestern.edu> <chris-diaz@northwestern.edu>
+Chris Fitzpatrick <cfitz@stanford.edu> <cfitz@stanford.edu>
+Chris Fitzpatrick <cfitz@stanford.edu> <cfitz@stanford.edu>
+Claire D'Ambrosio <claire.dambrosio@ubiquitypress.com> <claire.dambrosio@ubiquitypress.com@>
+Claire D'Ambrosio <claire.dambrosio@ubiquitypress.com> <claire.dambrosio@ubiquitypress.com>
+Colin Fulton <justcolin@gmail.com> Colin Fulton <fultonis@umich.edu>
+Colin Gross <grosscol@gmail.com> Colin Gross <grosscol@umich.edu>
+Dan Brubaker Horst <dan@brubakerhorst.com> <dan.brubaker.horst@gmail.com>
+Dan Brubaker Horst <dan@brubakerhorst.com> <dbrubak1@nd.edu>
+Dan Coughlin <dan.coughlin@gmail.com> <dan.coughlin@gmail.com>
+Dan Coughlin <dan.coughlin@gmail.com> Dan Coughlin <danny@psu.edu>
+Dan Kerchner <kerchner@users.noreply.github.com> <kerchner@gwu.edu>
+Daniel Pierce <dlpierce@indiana.edu> <dlpierce@indiana.edu>
+Daniel Pierce <dlpierce@indiana.edu> <dlpierce@indiana.edu>
+Daniel Pierce <dlpierce@indiana.edu> Daniel Pierce <dlpierce@users.noreply.github.com>
+David Chandek-Stark <dchandekstark@gmail.com>
+David Chandek-Stark <dchandekstark@gmail.com> <david.chandek.stark@duke.edu>
+David Chandek-Stark <dchandekstark@gmail.com> <dchandekstark@gmail.com>
+David Chandek-Stark <dchandekstark@gmail.com> dchandekstark <dchandekstark@gmail.com>
+dependabot[bot] <support@dependabot.com> <dependabot[bot]@users.noreply.github.com>
+Earley <earleyj@0587391293.wireless.umich.net> Earley <earleyj@m-d25q90jsfy13.local>
+Eben English <eenglish@bpl.org> Eben English <ebenenglish@users.noreply.github.com>
+Eliot Jordan <eliot.jordan@gmail.com> Eliot Jordan <eliotj@princeton.edu>
+Erin Fahy <eefahy@users.noreply.github.com> <efahy@stanford.edu>
+Esmé Cowles <escowles@ticklefish.org> <escowles@ucsd.edu>
+Fritz Freiheit <fritx@umich.edu> <fritx@umich.edu>
+Garrick Van Buren <garrickvanburen@slogin.gslogin.oscar.aol.com> Garrick Van Buren <garrickvanburen@Garrick-Van-Burens-MacBook-Pro.local>
+Glen Horton <hortongn@ucmail.uc.edu> <glen.horton@gmail.com>
+Gordon Leacock <gordonl@umich.edu> Gordon Leacock <gordonl@tang.umdl.umich.edu>
+Hector Correa <hector@hectorcorrea.com> Hector <hector@hectorcorrea.com>
+Hector Correa <hector@hectorcorrea.com> Hector Correa <hjc14@psu.edu>
+James R. Griffin III <jrgriffiniii@gmail.com> <griffinj@lafayette.edu>
+James R. Griffin III <jrgriffiniii@gmail.com> <jrg5@princeton.edu>
+James R. Griffin III <jrgriffiniii@gmail.com> <jrgriffiniii@gmail.com>
+Jamie Little <jamie@jamielittle.org> Jamie Little <j.little@miami.edu>
+Jesse Keck <jessie.keck@gmail.com> <jessie.keck@gmail.com>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@DN0a207065.SUNet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@DN0a207084.SUNet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@dn0a207096.sunet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@dn0a2071f4.sunet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@DN0a207204.SUNet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@DN0a207296.SUNet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@DN0a2072dd.SUNet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@DN0a207363.SUNet>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@stanford.edu>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@SUL-AC-TP-jk-2.local>
+Jesse Keck <jessie.keck@gmail.com> <jkeck@sul-mbp-jkeck.local>
+Johannes Frenzel <Johannes.Frenzel@gmail.com> <johannes.frenzel@gmail.com>
+Johannes Frenzel <Johannes.Frenzel@gmail.com> <johannes.frenzel@rub.de>
+Johannes Frenzel <Johannes.Frenzel@gmail.com> <johannes.frenzel@ruhr-uni-bochum.de>
+Johannes Frenzel <Johannes.Frenzel@gmail.com> Johannes Frenzel <Johannes Frenzel>
+John Scofield <john.scofield@yourmediashelf.com> <john@John-Scofields-MacBook.local>
+John Scofield <john.scofield@yourmediashelf.com> <jscofield@profitstreams.com>
+Jonathan Dixon <dixonj16@bi.vt.edu> <dixonj16@vbi.vt.edu>
+Jonathan Rochkind <jrochkind@sciencehistory.org> <jrochkind@chemheritage.org>
+Jonathan Rochkind <jrochkind@sciencehistory.org> <rochkind@xs001.mse.jhu.edu>
+Jose Blanco <blancoj@umich.edu> <blancoj@tang.umdl.umich.edu>
+Jose Blanco <blancoj@umich.edu> <blancoj@umich.edu>
+Jose Blanco <blancoj@umich.edu> Blanco <blancoj@158.128-25.43.211.141.in-addr.arpa>
+Josh Gum <revgum@gmail.com> <josh.gum@oregonstate.edu>
+Julie Allinson <geekscruff@gmail.com> <geekscruff@gmail.com>
+Julie Allinson <geekscruff@gmail.com> <julie.allinson@london.ac.uk>
+Julie Allinson <geekscruff@gmail.com> <julie.allinson@york.ac.uk>
+Julie Allinson <geekscruff@gmail.com> <julie@notch8.com>
+Justin Coyne <jcoyne@justincoyne.com> <digger250@gmail.com>
+Justin Coyne <jcoyne@justincoyne.com> <jcoyne@Fimafeng.lan>
+Justin Coyne <jcoyne@justincoyne.com> <justin.coyne@yourmediashelf.com>
+Justin Coyne <jcoyne@justincoyne.com> <justin@curationexperts.com>
+LaRita Robinson <laritakr@gmail.com> <lrobins5@nd.edu>
+Making GitHub Delicious <iron@waffle.io> <iron@waffle.io>
+Mark A. Matienzo <mark@matienzo.org> <mark.matienzo@gmail.com>
+Mark A. Matienzo <mark@matienzo.org> <matienzo@stanford.edu>
+Mark Bussey <mark@curationexperts.com> mark-dce <mark@curationexperts.com>
+Matt Critchlow <matt.critchlow@gmail.com> <matt.critchlow@gmail.com>
+Matt Zumwalt <matt@databindery.com> <matt.zumwalt@yourmediashelf.com>
+Matt Zumwalt <matt@databindery.com> <matt@curationexperts.com>
+Matt Zumwalt <matt@databindery.com> flyingzumwalt <matt.zumwalt@gmail.com>
+McClain Looney <m@loonsoft.com> <mlooney@mediashelf.us>
+Michael B. Klein <mbklein@gmail.com>
+Michael J. Giarlo <mjgiarlo@stanford.edu> <leftwing@alumni.rutgers.edu>
+Michael Tribone <mtribone@psu.edu> <mat141@psu.edu>
+Michael Tribone <mtribone@psu.edu> <mtribone@psu.edu>
+mpc3c <mpc3c@Virginia.EDU> <mpc3c@d-128-197-140.bootp.Virginia.EDU>
+mpc3c <mpc3c@Virginia.EDU> <mpc3c@d-128-53-77.bootp.Virginia.EDU>
+mpc3c <mpc3c@Virginia.EDU> <mpc3c@d-137-155-223.bootp.Virginia.EDU>
+mpc3c <mpc3c@Virginia.EDU> <mpc3c@d-137-155-225.bootp.Virginia.EDU>
+mpc3c <mpc3c@Virginia.EDU> <mpc3c@d-137-155-239.bootp.Virginia.EDU>
+mpc3c <mpc3c@Virginia.EDU> <mpc3c@mpc3c-macbookpro.local>
+Naomi Dushay <ndushay@stanford.edu> <ndushay@stanford.edu>
+Paul Clough <paclough@github> <p.a.clough@gmail.com>
+Phuong Dinh <phuongdh@gmail.com> <phuongdh@gmail.com>
+Rajesh Balekai <rbalekai@nd.edu> rbalekai <rbalekai@nd.edu>
+Randall Floyd <rdfloyd@indiana.edu> <rdfloyd@localhost.localdomain>
+Richard Johnson <rick.johnson@nd.edu> rickjohnson <rick.johnson@nd.edu>
+Richard Johnson <rick.johnson@nd.edu> rjohns14 <rjohns14@LIB-1224.library.nd.edu>
+Richard Johnson <rick.johnson@nd.edu> rjohns14@github.com <rjohns14@LIB-1224.library.nd.edu>
+Ruth Kitchin Tillman <rkt@ruthtillman.com> <ruthtillman@gmail.com>
+Sean Hannnan <shannan@jhu.edu> <shannan@jhu.edu>
+Steven Anderson <thephdgaming@gmail.com> <sanderson@bpl.org>
+Thomas Scherz <thomas.scherz@uc.edu> <scherztc@ucmail.uc.edu>
+Tim Donohue <tdonohue@duraspace.org> <tdonohue@duraspace.org>
+Tom Johnson <johnson.tom@gmail.com> <thomas.johnson@oregonstate.edu>
+Tom Johnson <johnson.tom@gmail.com> <tom@curationexperts.com>
+Tom Johnson <johnson.tom@gmail.com> <tom@dp.la>
+Tom Johnson <johnson.tom@gmail.com> <tomjohnson@ucsb.edu>
+Trey Pendragon <tpendragon@princeton.edu> <tpendragon@lib-stafftpendragon.local>
+Trey Pendragon <tpendragon@princeton.edu> <trey.terrell@oregonstate.edu>
+Trey Pendragon <tpendragon@princeton.edu> <tterrell@nat-oitwireless-inside-vapornet100-c-1338.Princeton.EDU>
+Trey Pendragon <tpendragon@princeton.edu> <tterrell@princeton.edu>
+Valerie Maher <val99erie@gmail.com> val99erie <val99erie@gmail.com>
+Ying Feng <yingfeng-iu@users.noreply.github.com> <yingfeng@iu.edu>
+Yinlin Chen <ylchen@vt.edu> <ylchen@vt.edu>

--- a/templates/MAILMAP
+++ b/templates/MAILMAP
@@ -58,6 +58,7 @@ Fritz Freiheit <fritx@umich.edu> <fritx@umich.edu>
 Garrick Van Buren <garrickvanburen@slogin.gslogin.oscar.aol.com> Garrick Van Buren <garrickvanburen@Garrick-Van-Burens-MacBook-Pro.local>
 Glen Horton <hortongn@ucmail.uc.edu> <glen.horton@gmail.com>
 Gordon Leacock <gordonl@umich.edu> Gordon Leacock <gordonl@tang.umdl.umich.edu>
+Gregory Wiedeman <gregory.wiedeman1@gmail.com> gwiedeman <gregory.wiedeman1@gmail.com>
 Hector Correa <hector@hectorcorrea.com> Hector <hector@hectorcorrea.com>
 Hector Correa <hector@hectorcorrea.com> Hector Correa <hjc14@psu.edu>
 James R. Griffin III <jrgriffiniii@gmail.com> <griffinj@lafayette.edu>
@@ -105,6 +106,7 @@ Mark Bussey <mark@curationexperts.com> mark-dce <mark@curationexperts.com>
 Matt Critchlow <matt.critchlow@gmail.com> <matt.critchlow@gmail.com>
 Matt Zumwalt <matt@databindery.com> <matt.zumwalt@yourmediashelf.com>
 Matt Zumwalt <matt@databindery.com> <matt@curationexperts.com>
+Matt Zumwalt <matt@databindery.com> <matt@drolkar-3.local>
 Matt Zumwalt <matt@databindery.com> flyingzumwalt <matt.zumwalt@gmail.com>
 McClain Looney <m@loonsoft.com> <mlooney@mediashelf.us>
 Michael B. Klein <mbklein@gmail.com>
@@ -118,6 +120,7 @@ mpc3c <mpc3c@Virginia.EDU> <mpc3c@d-137-155-225.bootp.Virginia.EDU>
 mpc3c <mpc3c@Virginia.EDU> <mpc3c@d-137-155-239.bootp.Virginia.EDU>
 mpc3c <mpc3c@Virginia.EDU> <mpc3c@mpc3c-macbookpro.local>
 Naomi Dushay <ndushay@stanford.edu> <ndushay@stanford.edu>
+Nicholas Woodward <njw@austin.utexas.edu> <woodward.nicholas@gmail.com>
 Paul Clough <paclough@github> <p.a.clough@gmail.com>
 Phuong Dinh <phuongdh@gmail.com> <phuongdh@gmail.com>
 Rajesh Balekai <rbalekai@nd.edu> rbalekai <rbalekai@nd.edu>
@@ -134,10 +137,12 @@ Tom Johnson <johnson.tom@gmail.com> <thomas.johnson@oregonstate.edu>
 Tom Johnson <johnson.tom@gmail.com> <tom@curationexperts.com>
 Tom Johnson <johnson.tom@gmail.com> <tom@dp.la>
 Tom Johnson <johnson.tom@gmail.com> <tomjohnson@ucsb.edu>
+Tom Johnson <johnson.tom@gmail.com> Tom Johnson <tomjohnson@ucsb.edu>
 Trey Pendragon <tpendragon@princeton.edu> <tpendragon@lib-stafftpendragon.local>
 Trey Pendragon <tpendragon@princeton.edu> <trey.terrell@oregonstate.edu>
 Trey Pendragon <tpendragon@princeton.edu> <tterrell@nat-oitwireless-inside-vapornet100-c-1338.Princeton.EDU>
 Trey Pendragon <tpendragon@princeton.edu> <tterrell@princeton.edu>
+Tricia Jenkins <tricia.g.jenkins@gmail.com> pgwillia <tricia.g.jenkins@gmail.com>
 Valerie Maher <val99erie@gmail.com> val99erie <val99erie@gmail.com>
 Ying Feng <yingfeng-iu@users.noreply.github.com> <yingfeng@iu.edu>
 Yinlin Chen <ylchen@vt.edu> <ylchen@vt.edu>


### PR DESCRIPTION
## Adding MAILMAP template

bb29fc0fae9944cb3633a9fb5f82e8f312c6d35c

I have scraped all of our `/^samvera(-.*)?/` repositories and
consolidated/normalized committer names. My local purpose has been to
run stats against our repositories in which I want to see the unique
contributors across the entire Samvera project.

**_Note:_** I do have scripts that I'm looking to generalize, but for
now am wanting to commit the following proposal:

> Should we collectively normalize the commit authors?

Assuming the answer is "yes", I would look to write scripts that would
help facilitate keeping this synchronized.
