### PR TITLE
WIP - Reworking the grant_revoke_gem_authority script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ and change roles/functions/laptops.
 ## Rake Tasks
 
 There exist rake tasks that can be used to propogate some of these templates.
+
+## Scripts
+
+* [./script/grant_revoke_gem_authority.rb](./script/grant_revoke_gem_authority.rb)
+  is a convenience script to synchronize authorship of Samvera
+  rubygems.

--- a/data/definitive-rubygems-authors-list.txt
+++ b/data/definitive-rubygems-authors-list.txt
@@ -1,0 +1,39 @@
+# This file has the definitive and declarative list of Samvera ruby
+# gems owners.  Each line must either be either an email address
+# of the associated Rubygems profile.
+aaron.collier@stanford.edu
+adam.wead@protonmail.com
+anna3lc@gmail.com
+armintor@gmail.com
+bess
+bmquinn
+cam156@psu.edu
+chris@cbeer.info
+cjcolvar
+dan.coughlin@gmail.com
+dchandekstark@gmail.com
+digger250@gmail.com
+drew@codhicitta.com
+dweber.consulting@gmail.com
+elrayle
+escowles@ticklefish.org
+glen.horton@gmail.com
+jenlindner@gmail.com
+jeremy.n.friesen@gmail.com
+jessie.keck@gmail.com
+johnson.tom@gmail.com
+jonathan@dnil.net
+jpstroop@gmail.com
+jrgriffiniii@gmail.com
+lawhorkl@mail.uc.edu
+leftwing@alumni.rutgers.edu
+mark@curationexperts.com
+mbklein@gmail.com
+mkorcy@gmail.com
+ndushay@stanford.edu
+ohiocore@gmail.com
+rachelkg@gmail.com
+randalldfloyd@gmail.com
+revgum@gmail.com
+thomas.scherz@uc.edu
+tpendragon@princeton.edu


### PR DESCRIPTION
Prior to this commit, we relied on Github usernames from Samvera to
dictate who had access to Rubygems.org.  I believe this created the
following problem:

First, we needed branching logic. Some github accounts had an
email/username that did not correspond to their Rubygems email/username.
Some github accounts had no corresponding Rubygems email/usernames.

This implied a somewhat confusing relationship that, in my opinion,
created more confusing code.

Second, I'm opting to leave the samvera-depcrated gems alone. You can
run WITH_DEPRECATED=true to update those gems.

Third, I'm attempting a single request that both adds and revokes
authors.  The reason being that I encountered throttling issues when I
ran the WITH_REVOKE using the prior logic.  I also added a sleep
directive so as to be a bit kinder against an unclear throttling
threshold.

Fourth, Valkyrie is now under the Samvera aegis, so I've removed it from
the special-case list.

Fifth, I have added a bit of progress reporting, namely printing to
stdout the current gem that the script is processing.

Sixth, I have encountered Rubygems throttling issues. Rubygems has a 10
requests per second rate limit ([see docs][1]). I thought at first we
could add all of the '-a' and '-r' switches in one request. However,
looking at the [implementation][2], the `owner` command calls the API
once per switch.

Please note, I have created the
`data/definitive-rubygems-authors-list.txt` to the best of my
ability. I'm certain I may have missed people.

[1]:https://guides.rubygems.org/rubygems-org-api/#rate-limits
[2]:https://github.com/rubygems/rubygems/blob/6edf24739fe76455af82491e539abbbbfd87b065/lib/rubygems/commands/owner_command.rb#L90