### PR TITLE
fix broken link to licensing and ownership doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All code contributors must have an Individual Contributor License Agreement
 an institution, the institution must have a Corporate Contributor License
 Agreement (cCLA) on file.
 
-https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
+[Samvera Community Intellectual Property Licensing and Ownership](https://samvera.atlassian.net/wiki/x/AwonG)
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 


### PR DESCRIPTION
The Samvera Community Intellectual Property Licensing and Ownership link points to the old wiki and no longer works.

